### PR TITLE
Add gitignore and secret handling guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+*.dylib
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+venv/
+.venv/
+*.egg-info/
+.eggs/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.cache
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints
+
+# MyPy
+.mypy_cache/
+.dmypy.json
+
+# Pyre
+.pyre/
+
+# VSCode
+.vscode/
+
+# Environment variables and secrets
+.env
+.env.*
+*.env
+*.local
+.streamlit/secrets.toml
+
+# Uploaded files
+uploaded_docs/
+
+# Misc
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# cluster
+# Document Analysis & RAG System
+
+This repository contains a Streamlit application for document analysis using RAG (Retrieval-Augmented Generation). The app allows users to upload files, query them via an LLM, summarize text, and perform simple clustering.
+
+## Running Locally
+
+Install the required packages and run Streamlit:
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+## Managing Secrets
+
+The application expects an OpenAI API key. You can provide it in two ways:
+
+1. **`.streamlit/secrets.toml`** – Create this file and define `OPENAI_API_KEY`:
+
+   ```toml
+   [general]
+   OPENAI_API_KEY = "sk-..."
+   ```
+
+2. **Environment variable** – Set `OPENAI_API_KEY` in your environment.
+
+Do **not** commit your actual `secrets.toml` file or any `.env` files. The provided `.gitignore` already excludes them to keep credentials private.
+
+Uploaded documents are stored in the `uploaded_docs/` directory and are also ignored by Git.


### PR DESCRIPTION
## Summary
- create a project `.gitignore` to exclude secrets, env files and uploaded docs
- expand `README.md` with instructions for managing OpenAI API keys using `.streamlit/secrets.toml` or environment variables

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688b16631e248330be66285a9375c982